### PR TITLE
Fix for FLEX-212: Spring Security integration does not work with Data Services NIO endpoints

### DIFF
--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/SpringSecurityLoginCommand.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/SpringSecurityLoginCommand.java
@@ -246,6 +246,11 @@ public class SpringSecurityLoginCommand implements LoginCommand, InitializingBea
      * @param authRequest the authentication request object that should have its details set
      */
     protected void setDetails(HttpServletRequest request, UsernamePasswordAuthenticationToken authRequest) {
-        authRequest.setDetails(authenticationDetailsSource.buildDetails(request));
+    	try {
+			authRequest.setDetails(authenticationDetailsSource.buildDetails(request));
+		} catch (Exception e) {
+			// This would happen e.g. for LCDS NIO Endpoints, which only have a "shell" request.
+			// Don't do anything.
+		}
     }
 }


### PR DESCRIPTION
FLEX-212: Spring Security integration does not work with Data Services NIO endpoints
It turns out due a change made for FLEX-185, the Security Login Command was changed so that the FlexContext.getHttpRequest() was being used used to set the source on the UserPasswordAuthenticationToken, which results in a silent error when passed a null value or a shell HttpRequest object (as is the case for NIO based endpoints). By ensuring that the code is enclosed in a try/catch block, this can be silently ignored if it happens. When we locally tested the fix, everything works.
