### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -35,17 +35,17 @@
     	<developer>
             <name>Jeremy Grelle</name>
             <organization>Pivotal Software, Inc.</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
         </developer>
         <developer>
             <name>Mark Fisher</name>
             <organization>Pivotal Software, Inc.</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
         </developer>
         <developer>
             <name>Sebastien Deleuze</name>
             <organization>Pivotal Software, Inc.</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
         </developer>
     </developers>
 
@@ -53,7 +53,7 @@
         <contributor>
             <name>Jose Barragan</name>
             <organization>Codeoscopic</organization>
-            <organizationUrl>http://www.codeoscopic.com</organizationUrl>
+            <organizationUrl>https://www.codeoscopic.com</organizationUrl>
         </contributor>
     </contributors>
 
@@ -162,8 +162,8 @@
                                     </groups>
                                     <excludePackageNames>org.springframework.flex.roo.addon:org.springframework.flex.samples</excludePackageNames>
                                     <links>
-                                        <link>http://docs.spring.io/spring/docs/current/javadoc-api</link>
-                                        <link>http://docs.spring.io/spring-security/site/docs/3.2.x/apidocs</link>
+                                        <link>https://docs.spring.io/spring/docs/current/javadoc-api</link>
+                                        <link>https://docs.spring.io/spring-security/site/docs/3.2.x/apidocs</link>
                                         <link>http://java.sun.com/javase/6/docs/api</link>
                                         <link>http://livedocs.adobe.com/blazeds/4/javadoc</link>
                                     </links>

--- a/spring-flex-core/pom.xml
+++ b/spring-flex-core/pom.xml
@@ -36,8 +36,8 @@
                                     <!-- copies doc-files subdirectory which contains image resources -->
                                     <docfilessubdirs>true</docfilessubdirs>
                                     <links>
-                                        <link>http://static.springframework.org/spring/docs/4.0.x/javadoc-api</link>
-                                        <link>http://static.springsource.org/spring-security/site/docs/4.0.x/apidocs</link>
+                                        <link>https://docs.spring.io/spring/docs/4.0.x/javadoc-api</link>
+                                        <link>https://docs.spring.io/spring-security/site/docs/4.0.x/apidocs</link>
                                         <link>http://java.sun.com/javase/6/docs/api</link>
                                         <link>http://livedocs.adobe.com/blazeds/4/javadoc</link>
                                     </links>

--- a/spring-flex-parent/pom.xml
+++ b/spring-flex-parent/pom.xml
@@ -18,7 +18,7 @@
     <licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -34,17 +34,17 @@
     	<developer>
     		<name>Jeremy Grelle</name>
     		<organization>Pivotal Software, Inc.</organization>
-    		<organizationUrl>http://www.spring.io</organizationUrl>
+    		<organizationUrl>https://www.spring.io</organizationUrl>
     	</developer>
     	<developer>
     		<name>Mark Fisher</name>
     		<organization>Pivotal Software, Inc.</organization>
-    		<organizationUrl>http://www.spring.io</organizationUrl>
+    		<organizationUrl>https://www.spring.io</organizationUrl>
     	</developer>
     	<developer>
     		<name>Sebastien Deleuze</name>
     		<organization>Pivotal Software, Inc.</organization>
-    		<organizationUrl>http://www.spring.io</organizationUrl>
+    		<organizationUrl>https://www.spring.io</organizationUrl>
     	</developer>
     </developers>
 
@@ -52,7 +52,7 @@
         <contributor>
             <name>Jose Barragan</name>
             <organization>Codeoscopic</organization>
-            <organizationUrl>http://www.codeoscopic.com</organizationUrl>
+            <organizationUrl>https://www.codeoscopic.com</organizationUrl>
         </contributor>
     </contributors>
 
@@ -399,7 +399,7 @@
 		<repository>
 			<id>repo.spring.io-ext-release-local</id>
 			<name>Spring repository for third party libraries</name>
-			<url>http://repo.spring.io/ext-release-local</url>
+			<url>https://repo.spring.io/ext-release-local</url>
 		</repository>
 	</repositories>
 

--- a/spring-flex-samples/spring-flex-testdrive/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/pom.xml
@@ -39,7 +39,7 @@
 
 		<repository>
 			<id>flex-mojos-repository</id>
-			<url>http://repository.sonatype.org/content/groups/flexgroup</url>
+			<url>https://repository.sonatype.org/content/groups/flexgroup</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -50,7 +50,7 @@
 
 		<repository>
 			<id>ObjectWEB</id>
-			<url>http://maven.ow2.org/maven2/</url>
+			<url>https://repository.ow2.org/nexus/content/repositories/ow2-legacy/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -64,7 +64,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>flex-mojos-repository</id>
-			<url>http://repository.sonatype.org/content/groups/flexgroup</url>
+			<url>https://repository.sonatype.org/content/groups/flexgroup</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://livedocs.adobe.com/blazeds/4/javadoc (404) migrated to:  
  http://livedocs.adobe.com/blazeds/4/javadoc ([https](https://livedocs.adobe.com/blazeds/4/javadoc) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://maven.ow2.org/maven2/ (301) migrated to:  
  https://repository.ow2.org/nexus/content/repositories/ow2-legacy/ ([https](https://maven.ow2.org/maven2/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.codeoscopic.com migrated to:  
  https://www.codeoscopic.com ([https](https://www.codeoscopic.com) result 200).
* http://docs.spring.io/spring-security/site/docs/3.2.x/apidocs migrated to:  
  https://docs.spring.io/spring-security/site/docs/3.2.x/apidocs ([https](https://docs.spring.io/spring-security/site/docs/3.2.x/apidocs) result 301).
* http://static.springsource.org/spring-security/site/docs/4.0.x/apidocs (301) migrated to:  
  https://docs.spring.io/spring-security/site/docs/4.0.x/apidocs ([https](https://static.springsource.org/spring-security/site/docs/4.0.x/apidocs) result 301).
* http://static.springframework.org/spring/docs/4.0.x/javadoc-api (301) migrated to:  
  https://docs.spring.io/spring/docs/4.0.x/javadoc-api ([https](https://static.springframework.org/spring/docs/4.0.x/javadoc-api) result 301).
* http://docs.spring.io/spring/docs/current/javadoc-api migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api ([https](https://docs.spring.io/spring/docs/current/javadoc-api) result 301).
* http://www.spring.io migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://repo.spring.io/ext-release-local migrated to:  
  https://repo.spring.io/ext-release-local ([https](https://repo.spring.io/ext-release-local) result 302).
* http://repository.sonatype.org/content/groups/flexgroup migrated to:  
  https://repository.sonatype.org/content/groups/flexgroup ([https](https://repository.sonatype.org/content/groups/flexgroup) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/javase/6/docs/api
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance