### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.flex</groupId>
     <artifactId>spring-flex</artifactId>
@@ -19,7 +19,7 @@
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -35,17 +35,17 @@
     	<developer>
             <name>Jeremy Grelle</name>
             <organization>Pivotal Software, Inc.</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
         </developer>
         <developer>
             <name>Mark Fisher</name>
             <organization>Pivotal Software, Inc.</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
         </developer>
         <developer>
             <name>Sebastien Deleuze</name>
             <organization>Pivotal Software, Inc.</organization>
-            <organizationUrl>http://www.spring.io</organizationUrl>
+            <organizationUrl>https://www.spring.io</organizationUrl>
         </developer>
     </developers>
 
@@ -53,7 +53,7 @@
         <contributor>
             <name>Jose Barragan</name>
             <organization>Codeoscopic</organization>
-            <organizationUrl>http://www.codeoscopic.com</organizationUrl>
+            <organizationUrl>https://www.codeoscopic.com</organizationUrl>
         </contributor>
     </contributors>
 
@@ -162,9 +162,9 @@
                                     </groups>
                                     <excludePackageNames>org.springframework.flex.roo.addon:org.springframework.flex.samples</excludePackageNames>
                                     <links>
-                                        <link>http://docs.spring.io/spring/docs/current/javadoc-api</link>
-                                        <link>http://docs.spring.io/spring-security/site/docs/3.2.x/apidocs</link>
-                                        <link>http://java.sun.com/javase/6/docs/api</link>
+                                        <link>https://docs.spring.io/spring/docs/current/javadoc-api</link>
+                                        <link>https://docs.spring.io/spring-security/site/docs/3.2.x/apidocs</link>
+                                        <link>https://java.sun.com/javase/6/docs/api</link>
                                         <link>http://livedocs.adobe.com/blazeds/4/javadoc</link>
                                     </links>
                                 </configuration>

--- a/spring-flex-core/pom.xml
+++ b/spring-flex-core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.flex</groupId>
@@ -36,9 +36,9 @@
                                     <!-- copies doc-files subdirectory which contains image resources -->
                                     <docfilessubdirs>true</docfilessubdirs>
                                     <links>
-                                        <link>http://static.springframework.org/spring/docs/4.0.x/javadoc-api</link>
-                                        <link>http://static.springsource.org/spring-security/site/docs/4.0.x/apidocs</link>
-                                        <link>http://java.sun.com/javase/6/docs/api</link>
+                                        <link>https://docs.spring.io/spring/docs/4.0.x/javadoc-api</link>
+                                        <link>https://docs.spring.io/spring-security/site/docs/4.0.x/apidocs</link>
+                                        <link>https://java.sun.com/javase/6/docs/api</link>
                                         <link>http://livedocs.adobe.com/blazeds/4/javadoc</link>
                                     </links>
                                 </configuration>

--- a/spring-flex-hibernate3/pom.xml
+++ b/spring-flex-hibernate3/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/spring-flex-hibernate4/pom.xml
+++ b/spring-flex-hibernate4/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/spring-flex-integration/pom.xml
+++ b/spring-flex-integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.flex</groupId>

--- a/spring-flex-parent/pom.xml
+++ b/spring-flex-parent/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.flex</groupId>
 	<artifactId>spring-flex-parent</artifactId>
@@ -18,7 +18,7 @@
     <licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -34,17 +34,17 @@
     	<developer>
     		<name>Jeremy Grelle</name>
     		<organization>Pivotal Software, Inc.</organization>
-    		<organizationUrl>http://www.spring.io</organizationUrl>
+    		<organizationUrl>https://www.spring.io</organizationUrl>
     	</developer>
     	<developer>
     		<name>Mark Fisher</name>
     		<organization>Pivotal Software, Inc.</organization>
-    		<organizationUrl>http://www.spring.io</organizationUrl>
+    		<organizationUrl>https://www.spring.io</organizationUrl>
     	</developer>
     	<developer>
     		<name>Sebastien Deleuze</name>
     		<organization>Pivotal Software, Inc.</organization>
-    		<organizationUrl>http://www.spring.io</organizationUrl>
+    		<organizationUrl>https://www.spring.io</organizationUrl>
     	</developer>
     </developers>
 
@@ -52,7 +52,7 @@
         <contributor>
             <name>Jose Barragan</name>
             <organization>Codeoscopic</organization>
-            <organizationUrl>http://www.codeoscopic.com</organizationUrl>
+            <organizationUrl>https://www.codeoscopic.com</organizationUrl>
         </contributor>
     </contributors>
 
@@ -398,7 +398,7 @@
 		<repository>
 			<id>repo.spring.io-ext-release-local</id>
 			<name>Spring repository for third party libraries</name>
-			<url>http://repo.spring.io/ext-release-local</url>
+			<url>https://repo.spring.io/ext-release-local</url>
 		</repository>
 	</repositories>
 

--- a/spring-flex-samples/spring-flex-testdrive/chat/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/chat/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/collaboration/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/collaboration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/companymgr/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/companymgr/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/feedstarter/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/feedstarter/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync-rest/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync01/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync01/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync02/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync02/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync03/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync03/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync04/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync04/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync05/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync05/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/insync06/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/insync06/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/jmschat/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/jmschat/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.flex</groupId>
@@ -39,7 +39,7 @@
 
 		<repository>
 			<id>flex-mojos-repository</id>
-			<url>http://repository.sonatype.org/content/groups/flexgroup</url>
+			<url>https://repository.sonatype.org/content/groups/flexgroup</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -50,7 +50,7 @@
 
 		<repository>
 			<id>ObjectWEB</id>
-			<url>http://maven.ow2.org/maven2/</url>
+			<url>https://repository.ow2.org/nexus/content/repositories/ow2-legacy/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -64,7 +64,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>flex-mojos-repository</id>
-			<url>http://repository.sonatype.org/content/groups/flexgroup</url>
+			<url>https://repository.sonatype.org/content/groups/flexgroup</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/spring-flex-samples/spring-flex-testdrive/secured/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/secured/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/simplepush/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/simplepush/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/spring-blazeds-101/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/spring-blazeds-101/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/spring-messaging/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/spring-messaging/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.flex.samples</groupId>

--- a/spring-flex-samples/spring-flex-testdrive/traderdesktop/pom.xml
+++ b/spring-flex-samples/spring-flex-testdrive/traderdesktop/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://livedocs.adobe.com/blazeds/4/javadoc (404) with 2 occurrences could not be migrated:  
   ([https](https://livedocs.adobe.com/blazeds/4/javadoc) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 2 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://maven.ow2.org/maven2/ (301) with 1 occurrences migrated to:  
  https://repository.ow2.org/nexus/content/repositories/ow2-legacy/ ([https](https://maven.ow2.org/maven2/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.codeoscopic.com with 2 occurrences migrated to:  
  https://www.codeoscopic.com ([https](https://www.codeoscopic.com) result 200).
* http://docs.spring.io/spring-security/site/docs/3.2.x/apidocs with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/3.2.x/apidocs ([https](https://docs.spring.io/spring-security/site/docs/3.2.x/apidocs) result 301).
* http://static.springsource.org/spring-security/site/docs/4.0.x/apidocs (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/4.0.x/apidocs ([https](https://static.springsource.org/spring-security/site/docs/4.0.x/apidocs) result 301).
* http://static.springframework.org/spring/docs/4.0.x/javadoc-api (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/4.0.x/javadoc-api ([https](https://static.springframework.org/spring/docs/4.0.x/javadoc-api) result 301).
* http://docs.spring.io/spring/docs/current/javadoc-api with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api ([https](https://docs.spring.io/spring/docs/current/javadoc-api) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 23 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.spring.io with 6 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://java.sun.com/javase/6/docs/api with 2 occurrences migrated to:  
  https://java.sun.com/javase/6/docs/api ([https](https://java.sun.com/javase/6/docs/api) result 302).
* http://repo.spring.io/ext-release-local with 1 occurrences migrated to:  
  https://repo.spring.io/ext-release-local ([https](https://repo.spring.io/ext-release-local) result 302).
* http://repository.sonatype.org/content/groups/flexgroup with 2 occurrences migrated to:  
  https://repository.sonatype.org/content/groups/flexgroup ([https](https://repository.sonatype.org/content/groups/flexgroup) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 50 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 25 occurrences