### PR TITLE
URL Cleanup

### DIFF
--- a/code-style/eclipse/eclipse_code-style_templates.xml
+++ b/code-style/eclipse/eclipse_code-style_templates.xml
@@ -44,7 +44,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/ivy.xml
+++ b/spring-flex-core/ivy.xml
@@ -6,7 +6,7 @@
 		version="1.3">
 		
 	<info organisation="org.springframework.flex" module="${ant.project.name}">
-		<license name="Apache 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+		<license name="Apache 2.0" url="https://www.apache.org/licenses/LICENSE-2.0"/>
 	</info>
 
 	<configurations>

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/BeanIds.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/BeanIds.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/FlexConfigurationManager.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/FlexConfigurationManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/MessageBrokerConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/MessageBrokerConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/RemotingAnnotationPostProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/RemotingAnnotationPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/RemotingDestinationMetadata.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/RemotingDestinationMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/RuntimeEnvironment.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/RuntimeEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/json/JsonConfigMapParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/json/JsonConfigMapParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/json/JsonConfigMapPropertyEditor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/json/JsonConfigMapPropertyEditor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/AbstractMessageDestinationBeanDefinitionParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/AbstractMessageDestinationBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/FlexNamespaceHandler.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/FlexNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/IntegrationMessageDestinationBeanDefinitionParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/IntegrationMessageDestinationBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/JmsMessageDestinationBeanDefinitionParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/JmsMessageDestinationBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/MessageBrokerBeanDefinitionParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/MessageBrokerBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/MessageDestinationBeanDefinitionParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/MessageDestinationBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/MessageInterceptors.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/MessageInterceptors.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/ParsingUtils.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/ParsingUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionDecorator.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionDecorator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionParser.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/RemotingDestinationExporterBeanDefinitionFactory.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/RemotingDestinationExporterBeanDefinitionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/SpringSecurity3ConfigHelper.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/SpringSecurity3ConfigHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/SpringSecurityConfigHelper.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/SpringSecurityConfigHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/config/xml/SpringSecurityConfigResolver.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/config/xml/SpringSecurityConfigResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/AbstractDestinationFactory.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/AbstractDestinationFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/AbstractServiceConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/AbstractServiceConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/CommonsLoggingTarget.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/CommonsLoggingTarget.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/DefaultExceptionLogger.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/DefaultExceptionLogger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/EndpointAdvisor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/EndpointAdvisor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/EndpointConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/EndpointConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/EndpointServiceMessagePointcutAdvisor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/EndpointServiceMessagePointcutAdvisor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/ExceptionLogger.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/ExceptionLogger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/ExceptionTranslationAdvice.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/ExceptionTranslationAdvice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/ExceptionTranslator.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/ExceptionTranslator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/LoginCommandConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/LoginCommandConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/ManageableComponentFactoryBean.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/ManageableComponentFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/MessageBrokerFactoryBean.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/MessageBrokerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/MessageInterceptionAdvice.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/MessageInterceptionAdvice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/MessageInterceptor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/MessageInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/MessageProcessingContext.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/MessageProcessingContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/AbstractAmfConversionServiceConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/AbstractAmfConversionServiceConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfCreator.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfIgnore.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfIgnore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfIgnoreField.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfIgnoreField.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfProperty.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/AmfProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/ClassPathScanningAmfConversionServiceConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/ClassPathScanningAmfConversionServiceConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/NumberConverter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/NumberConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/core/io/SpringPropertyProxy.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/core/io/SpringPropertyProxy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/http/AmfHttpMessageConverter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/http/AmfHttpMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/http/AmfView.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/http/AmfView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/AsyncMessageCreator.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/AsyncMessageCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/MessageDestinationFactory.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/MessageDestinationFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/MessageServiceConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/MessageServiceConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/MessageTemplate.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/MessageTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/SubscribeEvent.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/SubscribeEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/UnsubscribeEvent.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/UnsubscribeEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/integration/FlexHeaders.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/integration/FlexHeaders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/integration/IntegrationAdapter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/integration/IntegrationAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/jms/FlexMessageConverter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/jms/FlexMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/messaging/jms/JmsAdapter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/messaging/jms/JmsAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingDestination.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingDestination.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingDestinationExporter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingDestinationExporter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingExclude.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingExclude.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingInclude.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingInclude.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingServiceConfigProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/remoting/RemotingServiceConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/AntPathRequestMatcher.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/AntPathRequestMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/AuthenticationResultUtils.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/AuthenticationResultUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/EndpointInterceptor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/EndpointInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/EndpointSecurityMetadataSource.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/EndpointSecurityMetadataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/FlexAuthenticationEntryPoint.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/FlexAuthenticationEntryPoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/FlexSessionAwareSessionAuthenticationStrategy.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/FlexSessionAwareSessionAuthenticationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/LoginMessageInterceptor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/LoginMessageInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/PerClientAuthenticationInterceptor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/PerClientAuthenticationInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/SecurityConfigurationPostProcessor.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/SecurityConfigurationPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/SecurityExceptionTranslator.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/SecurityExceptionTranslator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/security3/SpringSecurityLoginCommand.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/security3/SpringSecurityLoginCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/main/java/org/springframework/flex/servlet/MessageBrokerHandlerAdapter.java
+++ b/spring-flex-core/src/main/java/org/springframework/flex/servlet/MessageBrokerHandlerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/AbstractFlexConfigurationTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/AbstractFlexConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/AbstractRuntimeEnvironmentAwareTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/AbstractRuntimeEnvironmentAwareTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/AnnotatedAutowiredRemoteBean.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/AnnotatedAutowiredRemoteBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/AnnotatedRemoteBean.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/AnnotatedRemoteBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/FlexConfigurationManagerTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/FlexConfigurationManagerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/RemotingAnnotationPostProcessorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/RemotingAnnotationPostProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/RuntimeEnvironmentTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/RuntimeEnvironmentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/TestWebInfResourceLoader.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/TestWebInfResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/json/JsonConfigMapPropertyEditorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/json/JsonConfigMapPropertyEditorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/AbstractMessageDestinationBeanDefinitionParserTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/AbstractMessageDestinationBeanDefinitionParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/IntegrationMessageDestinationBeanDefinitionParserTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/IntegrationMessageDestinationBeanDefinitionParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/JmsMessageDestinationBeanDefinitionParserTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/JmsMessageDestinationBeanDefinitionParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/MessageBrokerBeanDefinitionParserTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/MessageBrokerBeanDefinitionParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/MessageDestinationBeanDefinitionParserTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/MessageDestinationBeanDefinitionParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionDecoratorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionDecoratorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionParserTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/config/xml/RemotingDestinationBeanDefinitionParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/AbstractMessageBrokerTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/AbstractMessageBrokerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/EndpointConfigProcessorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/EndpointConfigProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/ExceptionTranslationAdviceTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/ExceptionTranslationAdviceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/ManageableComponentFactoryBeanTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/ManageableComponentFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/MessageBrokerFactoryBeanTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/MessageBrokerFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/MessageInterceptionAdviceTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/MessageInterceptionAdviceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/MessageDestinationFactoryTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/MessageDestinationFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/MessageServiceConfigProcessorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/MessageServiceConfigProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/MessageTemplateTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/MessageTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/FlexMessageConverterTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/FlexMessageConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/JmsDestinationTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/JmsDestinationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/StubMessage.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/StubMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/StubTextMessage.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/messaging/jms/StubTextMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/remoting/RemotingDestinationExporterTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/remoting/RemotingDestinationExporterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/remoting/RemotingServiceConfigProcessorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/remoting/RemotingServiceConfigProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointInterceptorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointInterceptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointSecurityIntegrationTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointSecurityIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointSecurityMetadataSourceTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointSecurityMetadataSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/LoginMessageInterceptorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/LoginMessageInterceptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/SecurityExceptionTranslatorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/SecurityExceptionTranslatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/SpringSecurityLoginCommandTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/SpringSecurityLoginCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/HibernateProxyConverter.java
+++ b/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/HibernateProxyConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/PersistentCollectionConverterFactory.java
+++ b/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/PersistentCollectionConverterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/config/HibernateConfigProcessor.java
+++ b/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/config/HibernateConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/config/HibernateSerializationConfigPostProcessor.java
+++ b/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/config/HibernateSerializationConfigPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/config/JpaHibernateConfigProcessor.java
+++ b/spring-flex-hibernate3/src/main/java/org/springframework/flex/hibernate3/config/JpaHibernateConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/AbstractFlexConfigurationTests.java
+++ b/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/AbstractFlexConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/AbstractRuntimeEnvironmentAwareTests.java
+++ b/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/AbstractRuntimeEnvironmentAwareTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/RuntimeEnvironmentTests.java
+++ b/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/RuntimeEnvironmentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/TestWebInfResourceLoader.java
+++ b/spring-flex-hibernate3/src/test/java/org/springframework/flex/hibernate3/config/TestWebInfResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/HibernateProxyConverter.java
+++ b/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/HibernateProxyConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/PersistentCollectionConverterFactory.java
+++ b/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/PersistentCollectionConverterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/config/HibernateConfigProcessor.java
+++ b/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/config/HibernateConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/config/HibernateSerializationConfigPostProcessor.java
+++ b/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/config/HibernateSerializationConfigPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/config/JpaHibernateConfigProcessor.java
+++ b/spring-flex-hibernate4/src/main/java/org/springframework/flex/hibernate4/config/JpaHibernateConfigProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/AbstractFlexConfigurationTests.java
+++ b/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/AbstractFlexConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/AbstractRuntimeEnvironmentAwareTests.java
+++ b/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/AbstractRuntimeEnvironmentAwareTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/RuntimeEnvironmentTests.java
+++ b/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/RuntimeEnvironmentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/TestWebInfResourceLoader.java
+++ b/spring-flex-hibernate4/src/test/java/org/springframework/flex/hibernate4/config/TestWebInfResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-integration/src/main/java/org/springframework/flex/integration/service/FooService.java
+++ b/spring-flex-integration/src/main/java/org/springframework/flex/integration/service/FooService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-integration/src/main/java/org/springframework/flex/integration/service/Ping.java
+++ b/spring-flex-integration/src/main/java/org/springframework/flex/integration/service/Ping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-integration/src/main/java/org/springframework/flex/integration/service/PingService.java
+++ b/spring-flex-integration/src/main/java/org/springframework/flex/integration/service/PingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/ivy.xml
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/ivy.xml
@@ -6,7 +6,7 @@
 		version="1.3">
 
 	<info organisation="org.springframework.flex.samples" module="${ant.project.name}">
-		<license name="Apache 2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+		<license name="Apache 2.0" url="https://www.apache.org/licenses/LICENSE-2.0"/>
 		<ivyauthor name="Jeremy Grelle"/>
 	</info>
 

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/company/Company.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/company/Company.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/company/CompanyDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/company/CompanyDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/company/ICompanyDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/company/ICompanyDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/contact/Contact.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/contact/Contact.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/contact/ContactDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/contact/ContactDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/contact/IContactDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/contact/IContactDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/dao/IGenericDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/dao/IGenericDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/industry/IIndustryDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/industry/IIndustryDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/industry/Industry.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/industry/Industry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/industry/IndustryDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/industry/IndustryDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/integration/Counter.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/integration/Counter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/jmschat/JMSChat.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/jmschat/JMSChat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/marketfeed/MarketFeed.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/marketfeed/MarketFeed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/marketfeed/Stock.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/marketfeed/Stock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/product/IProductDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/product/IProductDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/product/Product.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/product/Product.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/product/ProductDAO.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/product/ProductDAO.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/simplefeed/SimpleFeed.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/simplefeed/SimpleFeed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/util/DatabaseInitializer.java
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/java/org/springframework/flex/samples/util/DatabaseInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 156 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).