### PR TITLE
URL Cleanup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -146,7 +146,7 @@ Changes in version 1.0.2.RELEASE (02.08.2010)
 General
 * Spring Security 3 support has been added and the bundled Test Drive sample now has an additional Maven build 
 profile for building the sample to use Spring 3 and Spring Security 3.  See the docs at 
-http://static.springsource.org/spring-flex/docs/1.0.x/reference/html/ch06.html for instructions on how to enable
+https://docs.spring.io/spring-flex/docs/1.0.x/reference/html/ch06.html for instructions on how to enable
 this optional profile.
 
 Enhancements
@@ -202,7 +202,7 @@ Bug Fixes
 Changes in version 1.0.0.RELEASE (06.09.2009)
 -----------------------------------------
 General
-* Maven central compatible POMs will be mirrored to http://repo1.maven.org
+* Maven central compatible POMs will be mirrored to https://repo1.maven.org
 * Marked Jackson and CGLib dependencies as required in ivy and pom configurations since they are almost always needed in practice
 * Added documentation about using Spring MVC controllers alongside Spring BlazeDS Integration in the same application.
 
@@ -216,7 +216,7 @@ Changes in version 1.0.0.RC2 (05.19.2009)
 -----------------------------------------
 General
 * The Test Drive samples are now included in the distribution and configured for use with Eclipse WTP
-* Maven central compatible POMs have been published to the repository at http://maven.springframework.org/milestone/
+* Maven central compatible POMs have been published to the repository at https://maven.springframework.org/milestone/
 * Minor revisions to the documentation including a new chapter on working with the test drive sample 
 
 Enhancements
@@ -287,7 +287,7 @@ Bug Fixes
 Changes in version 1.0.0.M1 (12.15.2008)
 ----------------------------------------
 General
-* Performed an initial code drop at http://src.springframework.org/svn/spring-flex
+* Performed an initial code drop at https://src.springframework.org/svn/spring-flex
 * Organized project structure to use spring-build and create OSGi-ready build artifacts
 * Added an initial draft of the reference manual
 

--- a/docbkx/resources/xsl/highlight-fo.xsl
+++ b/docbkx/resources/xsl/highlight-fo.xsl
@@ -5,7 +5,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/docbkx/resources/xsl/highlight.xsl
+++ b/docbkx/resources/xsl/highlight.xsl
@@ -3,7 +3,7 @@
     Simple highlighter for HTML output. Follows the Eclipse color scheme.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/docbkx/resources/xsl/html.xsl
+++ b/docbkx/resources/xsl/html.xsl
@@ -5,7 +5,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"                
                 version="1.0">
                 
@@ -93,11 +93,11 @@
     <!-- let's have a Spring and I21 banner across the top of each page -->
     <xsl:template name="user.header.navigation">
         <div style="background-color:white;border:none;height:73px;border:1px solid black;">
-            <a style="border:none;" href="http://www.springframework.org/osgi/"
+            <a style="border:none;" href="https://www.springframework.org/osgi/"
                title="The Spring Framework - Spring Data">
                 <img style="border:none;" src="images/xdev-spring_logo.jpg"/>
             </a>
-            <a style="border:none;" href="http://www.SpringSource.com/" title="SpringSource - Spring from the Source">
+            <a style="border:none;" href="https://www.SpringSource.com/" title="SpringSource - Spring from the Source">
                 <img style="border:none;position:absolute;padding-top:5px;right:42px;" src="images/s2-banner-rhs.png"/>
             </a>
         </div>

--- a/docbkx/resources/xsl/html_chunk.xsl
+++ b/docbkx/resources/xsl/html_chunk.xsl
@@ -86,11 +86,11 @@
     <!-- let's have a Spring and I21 banner across the top of each page -->
     <xsl:template name="user.header.navigation">
         <div style="background-color:white;border:none;height:73px;border:1px solid black;">
-            <a style="border:none;" href="http://www.springframework.org/osgi/"
+            <a style="border:none;" href="https://www.springframework.org/osgi/"
                title="The Spring Framework - Spring Data">
                 <img style="border:none;" src="images/xdev-spring_logo.jpg"/>
             </a>
-            <a style="border:none;" href="http://www.SpringSource.com/" title="SpringSource - Spring from the Source">
+            <a style="border:none;" href="https://www.SpringSource.com/" title="SpringSource - Spring from the Source">
                 <img style="border:none;position:absolute;padding-top:5px;right:42px;" src="images/s2-banner-rhs.png"/>
             </a>
         </div>
@@ -200,7 +200,7 @@
                                 </td>
                                 <td width="20%" align="center">
                                     <span style="color:white;font-size:90%;">
-                                        <a href="http://www.SpringSource.com/"
+                                        <a href="https://www.SpringSource.com/"
                                            title="SpringSource - Spring from the Source">Sponsored by SpringSource
                                         </a>
                                     </span>

--- a/notice.txt
+++ b/notice.txt
@@ -4,13 +4,13 @@
    ======================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternately, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/readme.txt
+++ b/readme.txt
@@ -33,8 +33,8 @@ You will find issues one the Spring Flex JIRA at https://jira.spring.io/browse/F
 4. DISTRIBUTION JAR FILES
 -------------------------
 
-Spring Flex snapshot builds are available from http://repo.spring.io/libs-snapshot/
-SPring Flex release candidates are available from http://repo.spring.io/libs-milestone/
+Spring Flex snapshot builds are available from https://repo.spring.io/libs-snapshot/
+SPring Flex release candidates are available from https://repo.spring.io/libs-milestone/
 Spring Flex release builds are available from Maven Central.
 
 They are using the org.springframework.flex groupId.

--- a/spring-flex-core/src/main/resources/org/springframework/flex/config/xml/spring-flex-1.5.xsd
+++ b/spring-flex-core/src/main/resources/org/springframework/flex/config/xml/spring-flex-1.5.xsd
@@ -18,8 +18,8 @@ A XML-based DSL for configuring Spring BlazeDS Integration.
 		</xsd:documentation>
 	</xsd:annotation>
 	
-	<xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.0.xsd" />
-	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool-3.0.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="https://www.springframework.org/schema/beans/spring-beans-3.0.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="https://www.springframework.org/schema/tool/spring-tool-3.0.xsd" />
 	
 	
 	<xsd:element name="message-broker">

--- a/spring-flex-core/src/main/resources/org/springframework/flex/config/xml/spring-flex-1.6.xsd
+++ b/spring-flex-core/src/main/resources/org/springframework/flex/config/xml/spring-flex-1.6.xsd
@@ -18,8 +18,8 @@ A XML-based DSL for configuring Spring BlazeDS Integration.
 		</xsd:documentation>
 	</xsd:annotation>
 	
-	<xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" />
-	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool-4.0.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="https://www.springframework.org/schema/beans/spring-beans-4.0.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="https://www.springframework.org/schema/tool/spring-tool-4.0.xsd" />
 	
 	
 	<xsd:element name="message-broker">

--- a/spring-flex-core/src/test/java/org/springframework/flex/core/EndpointConfigProcessorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/core/EndpointConfigProcessorTests.java
@@ -78,18 +78,18 @@ public class EndpointConfigProcessorTests {
         this.broker = new MessageBroker();
 
         when(this.endpoint1.getId()).thenReturn("bar");
-        when(this.endpoint1.getUrl()).thenReturn("http://foo.com/bar");
+        when(this.endpoint1.getUrl()).thenReturn("http://www.foo.com/bar");
         when(this.endpoint1.serviceMessage(this.testMessage)).thenReturn(this.testMessage);
         this.broker.addEndpoint(this.endpoint1);
 
         when(this.endpoint2.getId()).thenReturn("baz");
-        when(this.endpoint2.getUrl()).thenReturn("http://foo.com/baz");
+        when(this.endpoint2.getUrl()).thenReturn("http://www.foo.com/baz");
         when(this.endpoint2.serviceMessage(this.testMessage)).thenReturn(this.testMessage);
         this.broker.addEndpoint(this.endpoint2);
         
         this.endpoint3 = new CustomEndpoint();
         this.endpoint3.setId("custom");
-        this.endpoint3.setUrl("http://foo.com/custom");
+        this.endpoint3.setUrl("http://www.foo.com/custom");
         this.broker.addEndpoint(this.endpoint3);
     }
 

--- a/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointInterceptorTests.java
+++ b/spring-flex-core/src/test/java/org/springframework/flex/security3/EndpointInterceptorTests.java
@@ -120,7 +120,7 @@ public class EndpointInterceptorTests {
 
     @Test
     public void serviceAuthorized() throws Exception {
-        when(this.endpoint.getUrlForClient()).thenReturn("http://foo.com/bar/spring/messagebroker/amf");
+        when(this.endpoint.getUrlForClient()).thenReturn("http://www.foo.com/bar/spring/messagebroker/amf");
         when(this.endpoint.serviceMessage(this.inMessage)).thenReturn(this.outMessage);
 
         List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
@@ -169,7 +169,7 @@ public class EndpointInterceptorTests {
 
     @Test
     public void serviceUnsecured() throws Exception {
-        when(this.endpoint.getUrlForClient()).thenReturn("http://foo.com/bar/spring/messagebroker/amfpolling");
+        when(this.endpoint.getUrlForClient()).thenReturn("http://www.foo.com/bar/spring/messagebroker/amfpolling");
         when(this.endpoint.serviceMessage(this.inMessage)).thenReturn(this.outMessage);
 
         Message result = this.advisedEndpoint.serviceMessage(this.inMessage);

--- a/spring-flex-integration/src/main/webapp/index.html
+++ b/spring-flex-integration/src/main/webapp/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/chat/chat.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/chat/chat.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "chat",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "chat",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="chat" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="chat.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/collaboration/collaboration.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/collaboration/collaboration.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "collaboration",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "collaboration",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="collaboration" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="collaboration.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/companymgr/companymgr.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/companymgr/companymgr.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "companymgr",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "companymgr",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="companymgr" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="companymgr.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/fb-project-setup.htm
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/fb-project-setup.htm
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/feedstarter/feedstarter.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/feedstarter/feedstarter.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "feedstarter",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "feedstarter",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="feedstarter" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="feedstarter.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/index.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
@@ -8,19 +8,19 @@
 <body>
 
 <h1>Spring BlazeDS Integration Test Drive</h1>
-<p>In this Test Drive, you  run a series of short sample applications that demonstrate the key features of Spring BlazeDS Integration. This Test Drive is a continual work in progress and will be updated with each release of the project. Please submit your feedback to the Spring BlazeDS Integration team via the <a href="http://forum.springsource.org/forumdisplay.php?f=61">project forum</a>.</p>
+<p>In this Test Drive, you  run a series of short sample applications that demonstrate the key features of Spring BlazeDS Integration. This Test Drive is a continual work in progress and will be updated with each release of the project. Please submit your feedback to the Spring BlazeDS Integration team via the <a href="https://forum.spring.io/forumdisplay.php?f=61">project forum</a>.</p>
 <p>These samples have been developed in collaboration between Adobe and SpringSource, with contributions from:</p> 
 <ul>
-<li><a href="http://coenraets.org">Christophe Coenraets</a></li>
-<li><a href="http://blog.springsource.com/author/jgrelle/">Jeremy Grelle</a></li>
-<li><a href="http://blog.springsource.com/author/markf/">Mark Fisher</a></li>
+<li><a href="http://coenraets.org/blog/">Christophe Coenraets</a></li>
+<li><a href="https://spring.io/team/jgrelle/">Jeremy Grelle</a></li>
+<li><a href="https://spring.io/team/markf/">Mark Fisher</a></li>
 </ul>
 <br />
 <div class="highlight">
 <h2>Spring Architecture</h2>
-<p>This version of the Test Drive uses a layered Spring configuration, with the core domain services and supporting infrastructure loaded in a root application context via the <a href="http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/web/context/ContextLoaderListener.html">ContextLoaderListener</a>, 
-and  both the Flex integration  and the Spring MVC RESTful  @Controllers configured separately via the <a href="http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/web/servlet/DispatcherServlet.html">DispatcherServlet's</a> child application context.  This layered approach with explicit separation of concerns is by no means required, but 
-it does have some benefits over a non-layered approach such as opening up the option of writing out-of-container <a href="http://static.springframework.org/spring/docs/2.5.x/reference/testing.html#testcontext-framework">integration tests</a> for the core domain services without having to load the web 
+<p>This version of the Test Drive uses a layered Spring configuration, with the core domain services and supporting infrastructure loaded in a root application context via the <a href="https://docs.spring.io/spring/docs/2.5.x/api/org/springframework/web/context/ContextLoaderListener.html">ContextLoaderListener</a>, 
+and  both the Flex integration  and the Spring MVC RESTful  @Controllers configured separately via the <a href="https://docs.spring.io/spring/docs/2.5.x/api/org/springframework/web/servlet/DispatcherServlet.html">DispatcherServlet's</a> child application context.  This layered approach with explicit separation of concerns is by no means required, but 
+it does have some benefits over a non-layered approach such as opening up the option of writing out-of-container <a href="https://docs.spring.io/spring/docs/2.5.x/reference/testing.html#testcontext-framework">integration tests</a> for the core domain services without having to load the web 
 infrastructure.</p>
 
 <h2>Samples Index</h2>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync-rest/rest.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync-rest/rest.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!-- saved from url=(0014)about:internet -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">	
     <!-- 
@@ -8,7 +8,7 @@
     for building rich Internet applications that get delivered via the
     Flash Player or to desktops via Adobe AIR. 
     
-    Learn more about Flex at http://flex.org 
+    Learn more about Flex at https://flex.org 
     // -->
     <head>
         <title></title>
@@ -71,7 +71,7 @@
 			</p>
 			<script type="text/javascript"> 
 				var pageHost = ((document.location.protocol == "https:") ? "https://" :	"http://"); 
-				document.write("<a href='http://www.adobe.com/go/getflashplayer'><img src='" 
+				document.write("<a href='https://www.adobe.com/go/getflashplayer'><img src='" 
 								+ pageHost + "www.adobe.com/images/shared/download_buttons/get_flash_player.gif' alt='Get Adobe Flash player' /></a>" ); 
 			</script> 
         </div>
@@ -96,8 +96,8 @@
                 		10.0.0 or greater is not installed.
                 	</p>
                 <!--<![endif]-->
-                    <a href="http://www.adobe.com/go/getflashplayer">
-                        <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash Player" />
+                    <a href="https://www.adobe.com/go/getflashplayer">
+                        <img src="https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash Player" />
                     </a>
                 <!--[if !IE]>-->
                 </object>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync-rest/swfobject.js
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync-rest/swfobject.js
@@ -1,5 +1,5 @@
-/*!	SWFObject v2.2 <http://code.google.com/p/swfobject/> 
-	is released under the MIT License <http://www.opensource.org/licenses/mit-license.php> 
+/*!	SWFObject v2.2 <https://code.google.com/p/swfobject/> 
+	is released under the MIT License <https://www.opensource.org/licenses/mit-license.php> 
 */
 
 var swfobject = function() {
@@ -42,7 +42,7 @@ var swfobject = function() {
 			windows = p ? /win/.test(p) : /win/.test(u),
 			mac = p ? /mac/.test(p) : /mac/.test(u),
 			webkit = /webkit/.test(u) ? parseFloat(u.replace(/^.*webkit\/(\d+(\.\d+)?).*$/, "$1")) : false, // returns either the webkit version or false if not webkit
-			ie = !+"\v1", // feature detection based on Andrea Giammarchi's solution: http://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html
+			ie = !+"\v1", // feature detection based on Andrea Giammarchi's solution: https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html
 			playerVersion = [0,0,0],
 			d = null;
 		if (typeof nav.plugins != UNDEF && typeof nav.plugins[SHOCKWAVE_FLASH] == OBJECT) {
@@ -146,7 +146,7 @@ var swfobject = function() {
 	}
 	
 	/* Cross-browser onload
-		- Based on James Edwards' solution: http://brothercake.com/site/resources/scripts/onload/
+		- Based on James Edwards' solution: https://brothercake.com/site/resources/scripts/onload/
 		- Will fire an event as soon as a web page including all of its assets are loaded 
 	 */
 	function addLoadEvent(fn) {
@@ -307,7 +307,7 @@ var swfobject = function() {
 	}
 	
 	/* Show the Adobe Express Install dialog
-		- Reference: http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75
+		- Reference: https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75
 	*/
 	function showExpressInstall(att, par, replaceElemIdStr, callbackFn) {
 		isExpressInstallActive = true;
@@ -537,7 +537,7 @@ var swfobject = function() {
 	}
 	
 	/* Cross-browser dynamic CSS creation
-		- Based on Bobby van der Sluis' solution: http://www.bobbyvandersluis.com/articles/dynamicCSS.php
+		- Based on Bobby van der Sluis' solution: https://www.bobbyvandersluis.com/articles/dynamicCSS.php
 	*/	
 	function createCSS(sel, decl, media, newStyle) {
 		if (ua.ie && ua.mac) { return; }
@@ -621,7 +621,7 @@ var swfobject = function() {
 	
 	return {
 		/* Public API
-			- Reference: http://code.google.com/p/swfobject/wiki/documentation
+			- Reference: https://code.google.com/p/swfobject/wiki/documentation
 		*/ 
 		registerObject: function(objectIdStr, swfVersionStr, xiSwfUrlStr, callbackFn) {
 			if (ua.w3 && objectIdStr && swfVersionStr) {

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync01/insync01.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync01/insync01.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "insync01",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "insync01",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="insync01" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="insync01.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync02/insync02.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync02/insync02.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "insync02",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "insync02",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="insync02" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="insync02.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync03/insync03.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync03/insync03.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "insync03",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "insync03",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="insync03" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="insync03.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync04/insync04.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync04/insync04.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "insync04",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "insync04",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="insync04" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="insync04.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync05/insync05.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync05/insync05.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "insync05",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "insync05",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="insync05" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="insync05.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync06/insync06.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/insync06/insync06.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "insync06",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "insync06",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="insync06" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="insync06.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/jmschat/jmschat.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/jmschat/jmschat.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "jmschat",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "jmschat",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="jmschat" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="jmschat.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/secured/secured.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/secured/secured.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "secured",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "secured",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="secured" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="secured.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/simplepush/simplepush.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/simplepush/simplepush.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "simplepush",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "simplepush",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="simplepush" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="simplepush.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#ffffff" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/spring-blazeds-101/main.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/spring-blazeds-101/main.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "main",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "main",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="main" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="main.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/spring-messaging/messaging.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/spring-messaging/messaging.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "messaging",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "messaging",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="messaging" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="messaging.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>

--- a/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/traderdesktop/traderdesktop.html
+++ b/spring-flex-samples/spring-flex-testdrive/testdrive/src/main/webapp/traderdesktop/traderdesktop.html
@@ -8,7 +8,7 @@ This application was built using Adobe Flex, an open source framework
 for building rich Internet applications that get delivered via the
 Flash Player or to desktops via Adobe AIR. 
 
-Learn more about Flex at http://flex.org 
+Learn more about Flex at https://flex.org 
 // -->
 
 <head>
@@ -72,7 +72,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 		"name", "traderdesktop",
 		"allowScriptAccess","sameDomain",
 		"type", "application/x-shockwave-flash",
-		"pluginspage", "http://www.adobe.com/go/getflashplayer"
+		"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
 } else if (hasRequestedVersion) {
 	// if we've detected an acceptable version
@@ -88,12 +88,12 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 			"name", "traderdesktop",
 			"allowScriptAccess","sameDomain",
 			"type", "application/x-shockwave-flash",
-			"pluginspage", "http://www.adobe.com/go/getflashplayer"
+			"pluginspage", "https://www.adobe.com/go/getflashplayer"
 	);
   } else {  // flash is too old or we can't detect the plugin
     var alternateContent = 'Alternate HTML content should be placed here. '
   	+ 'This content requires the Adobe Flash Player. '
-   	+ '<a href=http://www.adobe.com/go/getflash/>Get Flash</a>';
+   	+ '<a href=https://www.adobe.com/go/getflash/>Get Flash</a>';
     document.write(alternateContent);  // insert non-flash content
   }
 // -->
@@ -101,7 +101,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 <noscript>
   	<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
 			id="traderdesktop" width="100%" height="100%"
-			codebase="http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
+			codebase="https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab">
 			<param name="movie" value="traderdesktop.swf" />
 			<param name="quality" value="high" />
 			<param name="bgcolor" value="#869ca7" />
@@ -113,7 +113,7 @@ if ( hasProductInstall && !hasRequestedVersion ) {
 				quality="high"
 				allowScriptAccess="sameDomain"
 				type="application/x-shockwave-flash"
-				pluginspage="http://www.adobe.com/go/getflashplayer">
+				pluginspage="https://www.adobe.com/go/getflashplayer">
 			</embed>
 	</object>
 </noscript>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://javascript.nwbox.com/IEContentLoaded/ (200) with 1 occurrences could not be migrated:  
   ([https](https://javascript.nwbox.com/IEContentLoaded/) result SSLHandshakeException).
* [ ] http://coenraets.org (301) with 1 occurrences could not be migrated:  
   ([https](https://coenraets.org) result ConnectTimeoutException).
* [ ] http://foo.com/bar (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/bar) result SSLHandshakeException).
* [ ] http://foo.com/bar/spring/messagebroker/amf (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/bar/spring/messagebroker/amf) result SSLHandshakeException).
* [ ] http://foo.com/bar/spring/messagebroker/amfpolling (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/bar/spring/messagebroker/amfpolling) result SSLHandshakeException).
* [ ] http://foo.com/baz (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/baz) result SSLHandshakeException).
* [ ] http://foo.com/custom (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/custom) result SSLHandshakeException).
* [ ] http://xslthl.sf.net (301) with 3 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://flex.org (ConnectTimeoutException) with 17 occurrences migrated to:  
  https://flex.org ([https](https://flex.org) result ConnectTimeoutException).
* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 3 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* [ ] http://src.springframework.org/svn/spring-flex (UnknownHostException) with 1 occurrences migrated to:  
  https://src.springframework.org/svn/spring-flex ([https](https://src.springframework.org/svn/spring-flex) result UnknownHostException).
* [ ] http://blog.springsource.com/author/jgrelle/ (301) with 1 occurrences migrated to:  
  https://spring.io/team/jgrelle/ ([https](https://blog.springsource.com/author/jgrelle/) result 404).
* [ ] http://blog.springsource.com/author/markf/ (301) with 1 occurrences migrated to:  
  https://spring.io/team/markf/ ([https](https://blog.springsource.com/author/markf/) result 404).
* [ ] http://www.bobbyvandersluis.com/articles/dynamicCSS.php (301) with 1 occurrences migrated to:  
  https://www.bobbyvandersluis.com/articles/dynamicCSS.php ([https](https://www.bobbyvandersluis.com/articles/dynamicCSS.php) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://brothercake.com/site/resources/scripts/onload/ with 1 occurrences migrated to:  
  https://brothercake.com/site/resources/scripts/onload/ ([https](https://brothercake.com/site/resources/scripts/onload/) result 200).
* [ ] http://static.springsource.org/spring-flex/docs/1.0.x/reference/html/ch06.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-flex/docs/1.0.x/reference/html/ch06.html ([https](https://static.springsource.org/spring-flex/docs/1.0.x/reference/html/ch06.html) result 200).
* [ ] http://static.springframework.org/spring/docs/2.5.x/reference/testing.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.5.x/reference/testing.html ([https](https://static.springframework.org/spring/docs/2.5.x/reference/testing.html) result 200).
* [ ] http://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab with 16 occurrences migrated to:  
  https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab ([https](https://fpdownload.macromedia.com/get/flashplayer/current/swflash.cab) result 200).
* [ ] http://maven.springframework.org/milestone/ with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone/ ([https](https://maven.springframework.org/milestone/) result 200).
* [ ] http://repo.spring.io/libs-milestone/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone/ ([https](https://repo.spring.io/libs-milestone/) result 200).
* [ ] http://repo.spring.io/libs-snapshot/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/ ([https](https://repo.spring.io/libs-snapshot/) result 200).
* [ ] http://repo1.maven.org with 1 occurrences migrated to:  
  https://repo1.maven.org ([https](https://repo1.maven.org) result 200).
* [ ] http://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html with 1 occurrences migrated to:  
  https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html ([https](https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html) result 200).
* [ ] http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif with 1 occurrences migrated to:  
  https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif ([https](https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org/osgi/ with 2 occurrences migrated to:  
  https://www.springframework.org/osgi/ ([https](https://www.springframework.org/osgi/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-4.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-4.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-4.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool-3.0.xsd ([https](https://www.springframework.org/schema/tool/spring-tool-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/tool/spring-tool-4.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tool/spring-tool-4.0.xsd ([https](https://www.springframework.org/schema/tool/spring-tool-4.0.xsd) result 200).
* [ ] http://code.google.com/p/swfobject/ with 1 occurrences migrated to:  
  https://code.google.com/p/swfobject/ ([https](https://code.google.com/p/swfobject/) result 301).
* [ ] http://code.google.com/p/swfobject/wiki/documentation with 1 occurrences migrated to:  
  https://code.google.com/p/swfobject/wiki/documentation ([https](https://code.google.com/p/swfobject/wiki/documentation) result 301).
* [ ] http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/web/context/ContextLoaderListener.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.5.x/api/org/springframework/web/context/ContextLoaderListener.html ([https](https://static.springframework.org/spring/docs/2.5.x/api/org/springframework/web/context/ContextLoaderListener.html) result 301).
* [ ] http://static.springframework.org/spring/docs/2.5.x/api/org/springframework/web/servlet/DispatcherServlet.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.5.x/api/org/springframework/web/servlet/DispatcherServlet.html ([https](https://static.springframework.org/spring/docs/2.5.x/api/org/springframework/web/servlet/DispatcherServlet.html) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?f=61 (301) with 1 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=61 ([https](https://forum.springsource.org/forumdisplay.php?f=61) result 301).
* [ ] http://www.SpringSource.com/ with 3 occurrences migrated to:  
  https://www.SpringSource.com/ ([https](https://www.SpringSource.com/) result 301).
* [ ] http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75 with 1 occurrences migrated to:  
  https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75 ([https](https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75) result 301).
* [ ] http://www.adobe.com/go/getflash/ with 16 occurrences migrated to:  
  https://www.adobe.com/go/getflash/ ([https](https://www.adobe.com/go/getflash/) result 301).
* [ ] http://www.adobe.com/go/getflashplayer with 50 occurrences migrated to:  
  https://www.adobe.com/go/getflashplayer ([https](https://www.adobe.com/go/getflashplayer) result 301).
* [ ] http://www.opensource.org/licenses/mit-license.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/mit-license.php ([https](https://www.opensource.org/licenses/mit-license.php) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 1 occurrences
* http://java.sun.com/jstl/core_rt with 1 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:8080/flex-integration/spring/messagebroker/amf with 2 occurrences
* http://localhost:8080/flex-integration/spring/protected/messagebroker/amf with 1 occurrences
* http://localhost:8080/flex-integration/spring/protected2/messagebroker/amf with 1 occurrences
* http://localhost:8080/testdrive with 1 occurrences
* http://localhost:8080/testdrive/login.jsp with 1 occurrences
* http://localhost:8080/testdrive/messagebroker/amf with 15 occurrences
* http://localhost:8080/testdrive/messagebroker/amflongpolling with 7 occurrences
* http://localhost:8080/testdrive/messagebroker/amfpolling with 7 occurrences
* http://localhost:8080/testdrive/messagebroker/streamingamf with 6 occurrences
* http://ns.adobe.com/mxml/2009 with 27 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/flex with 5 occurrences
* http://www.springframework.org/schema/tool with 4 occurrences
* http://www.w3.org/1999/XSL/Format with 5 occurrences
* http://www.w3.org/1999/XSL/Transform with 5 occurrences
* http://www.w3.org/1999/xhtml with 3 occurrences
* http://www.w3.org/2001/XMLSchema with 2 occurrences